### PR TITLE
goforget: "Failed to update" error before complete decay

### DIFF
--- a/goforget/forget.go
+++ b/goforget/forget.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	VERSION     = "0.3"
+	VERSION     = "0.3.1"
 	showVersion = flag.Bool("version", false, "print version string")
 	httpAddress = flag.String("http", ":8080", "HTTP service address (e.g., ':8080')")
 	redisHost   = flag.String("redis-host", "", "Redis host in the form host:port:db.")
@@ -226,7 +226,7 @@ func main() {
 	for i := 0; i < *nWorkers; i++ {
 		workerWaitGroup.Add(1)
 		go func() {
-			UpdateRedis(updateChan)
+			UpdateRedis(updateChan, i)
 			workerWaitGroup.Done()
 		}()
 	}


### PR DESCRIPTION
I just started playing with this awesome tool, however I'm facing an issue: my bins get zero-ed pre-maturely after a while. This is all it takes to reproduce the issue for me:

http://127.0.0.1:8090/incr?distribution=topics&field=Foo&N=200
http://127.0.0.1:8090/incr?distribution=topics&field=Bar&N=100

Then refreshing "http://127.0.0.1:8090/dist?distribution=topics" periodically, I can see both bins decaying at a logical rate. However, after a while (with both bins still > 0 in score and probability) both bins become count:0 and p:0 and "Failed to update: topics" appears in the log.

Any clue what might be wrong? Or is this the expected behavior? Thanks.
