### PR TITLE
don't panic on CLI parsing missing args

### DIFF
--- a/goforget/redis_utils.go
+++ b/goforget/redis_utils.go
@@ -26,7 +26,7 @@ type RedisServer struct {
 func NewRedisServer(rawString string, MaxIdle int) *RedisServer {
 	parts := strings.Split(rawString, ":")
 	if len(parts) != 3 {
-		log.Panicf("redis-host must be in the form host:port:db")
+		log.Fatal("redis-host must be in the form host:port:db")
 	}
 	rs := &RedisServer{
 		Raw:      rawString,


### PR DESCRIPTION
If the user doesn’t provide a RedisServer URL in the CLI arguments, just 
print the error message and exit gracefully with a fatal exit code.  No 
need to panic and dump a stack trace.
