### PR TITLE
Parse redis-uri at CLI, and allow for redis AUTH

### DIFF
--- a/goforget/forget.go
+++ b/goforget/forget.go
@@ -18,6 +18,7 @@ var (
 	showVersion = flag.Bool("version", false, "print version string")
 	httpAddress = flag.String("http", ":8080", "HTTP service address (e.g., ':8080')")
 	redisHost   = flag.String("redis-host", "", "Redis host in the form host:port:db.")
+	redisUri    = flag.String("redis-uri", "", "Redis URI in the form redis://:password@hostname:port/db_number")
 	defaultRate = flag.Float64("default-rate", 0.5, "Default rate to decay distributions with")
 	nWorkers    = flag.Int("nworkers", 1, "Number of update workers that update the redis DB")
 	pruneDist   = flag.Bool("prune", true, "Whether or not to decay distributional fields out")
@@ -232,6 +233,18 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 	redisServer = NewRedisServer(*redisHost, *nWorkers*2)
+	if *redisUri != "" {
+		// if a redis URI exists was specified, parse it
+		redisServer = NewRedisServerFromUri(*redisUri)
+	} else if *redisHost != "" {
+		// for legacy mode
+		redisServer = NewRedisServerFromRaw(*redisHost)
+	} else {
+		redisServer = NewRedisServerFromUri("redis://localhost:6379/1")
+	}
+
+	// create the connection pool
+	redisServer.Connect(*nWorkers * 2)
 
 	log.Printf("Starting %d update worker(s)", *nWorkers)
 	workerWaitGroup := sync.WaitGroup{}

--- a/goforget/redis_utils_test.go
+++ b/goforget/redis_utils_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testUriCases = []struct {
+	uriString   string
+	expected    *RedisServer
+	description string
+}{
+	{
+		uriString: "redis://localhost:6379",
+		expected: &RedisServer{
+			Host:     "localhost",
+			Port:     "6379",
+			hostname: "localhost:6379",
+			Db:       "0",
+			Pass:     "",
+		},
+		description: "typical case",
+	},
+	{
+		uriString: "redis://redisproviders.com:12345/4",
+		expected: &RedisServer{
+			Host:     "redisproviders.com",
+			Port:     "12345",
+			hostname: "redisproviders.com:12345",
+			Db:       "4",
+			Pass:     "",
+		},
+		description: "host, port, db",
+	},
+	{
+		uriString: "redis://10.0.0.1",
+		expected: &RedisServer{
+			Host:     "10.0.0.1",
+			Port:     "6379",
+			hostname: "10.0.0.1:6379",
+			Db:       "0",
+			Pass:     "",
+		},
+		description: "host-only ip (guess default port and db)",
+	},
+	{
+		uriString: "redis://10.0.0.1",
+		expected: &RedisServer{
+			Host:     "10.0.0.1",
+			Port:     "6379",
+			hostname: "10.0.0.1:6379",
+			Db:       "0",
+			Pass:     "",
+		},
+		description: "with password (no username)",
+	},
+	{
+		uriString: "redis://oakland:ratchets@redis.bitly.com:999/1",
+		expected: &RedisServer{
+			Host:     "redis.bitly.com",
+			Port:     "999",
+			hostname: "redis.bitly.com:999",
+			Db:       "1",
+			Pass:     "ratchets",
+		},
+		description: "everything URI (username should be ignored)",
+	},
+}
+
+var testRawCases = []struct {
+	rawString   string
+	expected    *RedisServer
+	description string
+}{
+	{
+		rawString: "localhost:6379:1",
+		expected: &RedisServer{
+			Host:     "localhost",
+			Port:     "6379",
+			hostname: "localhost:6379",
+			Db:       "1",
+			Pass:     "",
+		},
+		description: "typical case (all fields)",
+	},
+}
+
+func TestNewRedisServerFromUri(t *testing.T) {
+	for _, tt := range testUriCases {
+		expected := tt.expected
+		actual := NewRedisServerFromUri(tt.uriString)
+		if reflect.DeepEqual(expected, actual) {
+			t.Logf("PASS: %s", tt.description)
+		} else {
+			t.Errorf("FAIL: %s, expected: %+v, actual: %+v", tt.description, expected, actual)
+		}
+	}
+}
+
+func TestNewRedisServerFromRaw(t *testing.T) {
+	for _, tt := range testRawCases {
+		expected := tt.expected
+		actual := NewRedisServerFromRaw(tt.rawString)
+		if reflect.DeepEqual(expected, actual) {
+			t.Logf("PASS: %s", tt.description)
+		} else {
+			t.Errorf("FAIL: %s, expected: %+v, actual: %+v", tt.description, expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
  - Allow for authentication to a Redis server that is protected by a
password.
  - Adds `-redis-uri=` CLI argument for specifying the redis connection
    information in standard URI notation.  This is the default assumed
by many
    12-factor apps. The implementation here will also use Redis
defaults for
    any fields not specified by the user (port, db number).
  - If no redis information is specified, use default case (e.g.
    `redis://localhost:6379/0`)
  - Check for connection error when first creating Redis connection
pool at
    startup -- if found, inform user and die gracefully.