### PR TITLE
Fixed missing return on error in DBSizeHandler

### DIFF
--- a/goforget/forget.go
+++ b/goforget/forget.go
@@ -162,6 +162,7 @@ func DBSizeHandler(w http.ResponseWriter, r *http.Request) {
 	size, err := DBSize()
 	if err != nil {
 		HttpError(w, 500, "COULD_NOT_READ_SIZE")
+		return
 	}
 	HttpResponse(w, 200, size/3)
 }


### PR DESCRIPTION
If DBSize() returns an err, DBSizeHandler still continues with the code execution. Simple return after printing the error fixed it. 
Fixes: "http: multiple response.WriteHeader calls" error. 