### PR TITLE
fix issue arising from missing  NewRedisServer

### DIFF
--- a/goforget/forget.go
+++ b/goforget/forget.go
@@ -232,15 +232,13 @@ func main() {
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	redisServer = NewRedisServer(*redisHost, *nWorkers*2)
+	redisServer = NewRedisServerFromUri("redis://localhost:6379/1")
 	if *redisUri != "" {
 		// if a redis URI exists was specified, parse it
 		redisServer = NewRedisServerFromUri(*redisUri)
 	} else if *redisHost != "" {
 		// for legacy mode
 		redisServer = NewRedisServerFromRaw(*redisHost)
-	} else {
-		redisServer = NewRedisServerFromUri("redis://localhost:6379/1")
 	}
 
 	// create the connection pool


### PR DESCRIPTION
https://github.com/bitly/forgettable/commit/43cbf80431ead2540d96c2b7384b3672a90d45e3 removed NewRedisServer, but forget.go was still using it. 

This commit just uses NewRedisServerFromUri with default uri in its place.
